### PR TITLE
Added integration with proposed Web Checkout JS lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ xcuserdata/
 *.moved-aside
 *.xccheckout
 *.xcscmblueprint
+.DS_Store
 
 ## Obj-C/Swift specific
 *.hmap

--- a/Supporting Files/index.html
+++ b/Supporting Files/index.html
@@ -1,46 +1,32 @@
 <html>
-    <script>
-        // Function called from the web button
-        function checkoutButtonTapped() {
-            try {
-                var paymentJSON = encodeURIComponent("\"paymentType\":\"Apple Pay\", \"amount\":$33.3")
-                webkit.messageHandlers.poqAppCallBackFromWeb.postMessage(paymentJSON);
-            } catch(err) {
-                console.log('Can not reach native code');
-            }
-        }
-    
-        // Function called from Native
-        function setupApplePayButton() {
-            changeColorCheckoutNowButton()
-        }
-    
-        // Helpers
-        
-        function changeColorCheckoutNowButton() {
-            document.getElementById("paymentButton").style.color = getRandomColor();
-        }
-        
-        function getRandomColor() {
-            var letters = '0123456789ABCDEF';
-            var color = '#';
-            for (var i = 0; i < 6; i++) {
-                color += letters[Math.floor(Math.random() * 16)];
-            }
-            return color;
-        }
-    </script>
     <head>
-        <style type="text/css">
-            h1{font-family:"Helvetia Neue;";color:000000;font-size:50;text-align:center;padding:10px; }
-            p{font-family:"Helvetia Neue;";font-size:15 ;color:000000;text-align:center; text-align: justify}
-            </style>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <link rel="stylesheet" href="http://127.0.0.1:8080/dist/apple-pay.min.css">
+        <style>
+            body {
+                font-family: system-ui;
+            }
+            h1 {
+                text-align: center;
+            }
+        </style>
     </head>
     <body>
-        </br>
-        </br>
-        </br>
-        <h1> You have 1 item in your bag with a total price of $33.3 </h1>
-        <input type="button" name="Checkout" id="paymentButton" value="WEB Checkout Now"/ class="btn"  style="font-size : 80px; width: 100%; height: 100px;" onclick="checkoutButtonTapped();" />
+        <h1>Web Checkout</h1>
+        <h3>You have 1 item in your bag with a total price of $33.3 </h3>
+        <button type="button">Regular Web Checkout</button>
+        <br>
+        <br>
+        <div class="poqApplePayButtonContainer"></div>
+        <div id="applePayResponse"></div>
+        <script src="http://127.0.0.1:8080/dist/web-checkout.min.js"></script>
+        <script src="http://127.0.0.1:8080/dist/apple-pay.min.js"></script>
+        <script>
+            const checkout = new WebCheckout();
+            const applePay = new ApplePay(checkout);
+            checkout.on('paymentauthorized', event => {
+                document.getElementById('applePayResponse').textContent = JSON.stringify(event);
+            });
+        </script>
     </body>
 </html>

--- a/Supporting Files/index.html
+++ b/Supporting Files/index.html
@@ -24,6 +24,9 @@
         <script>
             const checkout = new WebCheckout();
             const applePay = new ApplePay(checkout);
+            checkout.on('applepayenabled', () => {
+                document.getElementById('applePayResponse').textContent = 'Apple Pay is available!'
+            });
             checkout.on('paymentauthorized', event => {
                 document.getElementById('applePayResponse').textContent = JSON.stringify(event);
             });

--- a/WKWebViewBridge.xcodeproj/project.pbxproj
+++ b/WKWebViewBridge.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		9FE908D1219C863E00880B15 /* WKWebViewBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FE908D0219C863E00880B15 /* WKWebViewBridgeTests.swift */; };
 		9FE908DC219C863E00880B15 /* WKWebViewBridgeUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FE908DB219C863E00880B15 /* WKWebViewBridgeUITests.swift */; };
 		9FE908EB219C882800880B15 /* index.html in Resources */ = {isa = PBXBuildFile; fileRef = 9FE908EA219C882800880B15 /* index.html */; };
+		BC7D683F21A2C7E800D5AD4E /* WebCheckoutPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC7D683E21A2C7E800D5AD4E /* WebCheckoutPayload.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -50,6 +51,7 @@
 		9FE908DD219C863E00880B15 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9FE908EA219C882800880B15 /* index.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = index.html; sourceTree = "<group>"; };
 		9FE908EE219DE84000880B15 /* WKWebViewBridge.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = WKWebViewBridge.entitlements; sourceTree = "<group>"; };
+		BC7D683E21A2C7E800D5AD4E /* WebCheckoutPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCheckoutPayload.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -108,6 +110,7 @@
 				9FE908C2219C863D00880B15 /* Assets.xcassets */,
 				9FE908C4219C863D00880B15 /* LaunchScreen.storyboard */,
 				9FE908C7219C863D00880B15 /* Info.plist */,
+				BC7D683E21A2C7E800D5AD4E /* WebCheckoutPayload.swift */,
 			);
 			path = WKWebViewBridge;
 			sourceTree = "<group>";
@@ -277,6 +280,7 @@
 			files = (
 				9FE908BE219C863B00880B15 /* ViewController.swift in Sources */,
 				9FE908BC219C863B00880B15 /* AppDelegate.swift in Sources */,
+				BC7D683F21A2C7E800D5AD4E /* WebCheckoutPayload.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WKWebViewBridge.xcodeproj/project.pbxproj
+++ b/WKWebViewBridge.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		9FE908BC219C863B00880B15 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FE908BB219C863B00880B15 /* AppDelegate.swift */; };
-		9FE908BE219C863B00880B15 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FE908BD219C863B00880B15 /* ViewController.swift */; };
+		9FE908BE219C863B00880B15 /* WebCheckoutController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FE908BD219C863B00880B15 /* WebCheckoutController.swift */; };
 		9FE908C1219C863B00880B15 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9FE908BF219C863B00880B15 /* Main.storyboard */; };
 		9FE908C3219C863D00880B15 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9FE908C2219C863D00880B15 /* Assets.xcassets */; };
 		9FE908C6219C863D00880B15 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9FE908C4219C863D00880B15 /* LaunchScreen.storyboard */; };
@@ -38,7 +38,7 @@
 /* Begin PBXFileReference section */
 		9FE908B8219C863B00880B15 /* WKWebViewBridge.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WKWebViewBridge.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9FE908BB219C863B00880B15 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		9FE908BD219C863B00880B15 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		9FE908BD219C863B00880B15 /* WebCheckoutController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCheckoutController.swift; sourceTree = "<group>"; };
 		9FE908C0219C863B00880B15 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		9FE908C2219C863D00880B15 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		9FE908C5219C863D00880B15 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -105,7 +105,7 @@
 			children = (
 				9FE908EE219DE84000880B15 /* WKWebViewBridge.entitlements */,
 				9FE908BB219C863B00880B15 /* AppDelegate.swift */,
-				9FE908BD219C863B00880B15 /* ViewController.swift */,
+				9FE908BD219C863B00880B15 /* WebCheckoutController.swift */,
 				9FE908BF219C863B00880B15 /* Main.storyboard */,
 				9FE908C2219C863D00880B15 /* Assets.xcassets */,
 				9FE908C4219C863D00880B15 /* LaunchScreen.storyboard */,
@@ -278,7 +278,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9FE908BE219C863B00880B15 /* ViewController.swift in Sources */,
+				9FE908BE219C863B00880B15 /* WebCheckoutController.swift in Sources */,
 				9FE908BC219C863B00880B15 /* AppDelegate.swift in Sources */,
 				BC7D683F21A2C7E800D5AD4E /* WebCheckoutPayload.swift in Sources */,
 			);

--- a/WKWebViewBridge/Base.lproj/Main.storyboard
+++ b/WKWebViewBridge/Base.lproj/Main.storyboard
@@ -12,7 +12,7 @@
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="WKWebViewBridge" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="WebCheckoutController" customModule="WKWebViewBridge" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/WKWebViewBridge/ViewController.swift
+++ b/WKWebViewBridge/ViewController.swift
@@ -10,25 +10,20 @@ import UIKit
 import WebKit
 import PassKit
 
-class ViewController: UIViewController, WKNavigationDelegate, WKScriptMessageHandler {
+class ViewController: UIViewController, WKNavigationDelegate {
     
     var webView: WKWebView?
     var changeColorButton: UIButton?
+    var applePayController: PKPaymentAuthorizationViewController?
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        // Set up for call backs from web
+        // Set up a message handler to receive data from Web Checkout JS
         let userContentController = WKUserContentController()
-        userContentController.add(self, name: "poqAppCallBackFromWeb")
+        userContentController.add(self, name: "webCheckout")
         let webViewConfiguration = WKWebViewConfiguration()
         webViewConfiguration.userContentController = userContentController
-        
-        
-        // Set up call to web
-        var userScript = WKUserScript(source: "setupApplePayButton()", injectionTime: .atDocumentEnd, forMainFrameOnly: true)
-        userContentController.addUserScript(userScript)
-        
         
         // Webview setup
         webView = WKWebView(frame: self.view.frame, configuration: webViewConfiguration)
@@ -38,51 +33,61 @@ class ViewController: UIViewController, WKNavigationDelegate, WKScriptMessageHan
         // Load the website
         let url = Bundle.main.url(forResource: "index", withExtension: "html")!
         webView?.loadFileURL(url, allowingReadAccessTo: url)
-        
-        // Add Native button
-        changeColorButton = UIButton()
-        if let button = changeColorButton {
-            button.translatesAutoresizingMaskIntoConstraints = false
-            self.view.addSubview(button)
-            button.setTitle("Change Checkout Now Button Color", for: .normal)
-            button.setTitleColor(.black, for: .normal)
-            button.addTarget(self, action:#selector(changeColorCheckoutNowButton), for: .touchUpInside)
-            button.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: -50).isActive = true
-            button.centerXAnchor.constraint(equalTo: self.view.centerXAnchor).isActive = true
-        }
-    }
-
-    // MARK: - WKScriptMessageHandler
-    
-    // Handles the call backs from the web
-    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
-        
-        guard let body = message.body as? String else {
-            return
-        }
-
-        let request = PKPaymentRequest()
-        request.countryCode = "US"
-        request.currencyCode = "USD"
-        request.paymentSummaryItems = [
-            PKPaymentSummaryItem(label: "T-shirt", amount: 33.3),
-        ]
-        request.supportedNetworks = [PKPaymentNetwork.amex]
-        request.merchantCapabilities = PKMerchantCapability.capability3DS
-        request.merchantIdentifier = "merchant.com.poqstudio.WKWebViewBridge"
-        let applePayController = PKPaymentAuthorizationViewController(paymentRequest: request)
-        self.present(applePayController!, animated: true, completion: nil)
-    }
-
-    @objc func changeColorCheckoutNowButton() {
-        webView?.evaluateJavaScript("changeColorCheckoutNowButton();", completionHandler: nil)
     }
 }
 
 extension ViewController: PKPaymentAuthorizationViewControllerDelegate {
     func paymentAuthorizationViewControllerDidFinish(_ controller: PKPaymentAuthorizationViewController) {
+        applePayController?.dismiss(animated: true, completion: nil)
         
+        let data: [String : String] = [
+            "applePayToken": "example-token-123"
+        ]
+        let encoder = JSONEncoder()
+        let jsonObject = try! encoder.encode(data)
+        let payload = String(data: jsonObject, encoding: .utf8)!
+        webView?.evaluateJavaScript("window.poqWebCheckout.postMessage('paymentauthorized', '" + payload + "')", completionHandler: nil)
     }
-    
+}
 
+extension ViewController: WKScriptMessageHandler {
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        let body = message.body as! String
+        
+        guard let data = body.data(using: .utf8),
+            let payload = try? JSONDecoder().decode(WebCheckoutPayload.self, from: data) else {
+            print("Error: Couldn't decode Payload from Web Checkout JS")
+            return
+        }
+        
+        switch(payload.name) {
+        case "setorder":
+            print("Order updated")
+            print(payload.data)
+        case "applepay":
+            print("User requested to pay via Apple Pay")
+            
+            let cartTotal: NSDecimalNumber = 33.3
+            
+            let request = PKPaymentRequest()
+            // Use the correct currency code here
+            request.countryCode = "US"
+            request.currencyCode = "GBP"
+            request.paymentSummaryItems = [
+                // Label should be the name of the merchant
+                PKPaymentSummaryItem(label: "Poq", amount: cartTotal)
+            ]
+            request.supportedNetworks = [PKPaymentNetwork.amex]
+            request.merchantCapabilities = PKMerchantCapability.capability3DS
+            // Replace with the merchant's identifier
+            request.merchantIdentifier = "merchant.com.poqstudio.WKWebViewBridge"
+            applePayController = PKPaymentAuthorizationViewController(paymentRequest: request)
+            applePayController?.delegate = self
+            self.present(applePayController!, animated: true, completion: nil)
+        case "closewebview":
+            print("Close the Web View")
+        default:
+            print("Error: Unknown event " + message.name + " from Web Checkout JS")
+        }
+    }
 }

--- a/WKWebViewBridge/WebCheckoutPayload.swift
+++ b/WKWebViewBridge/WebCheckoutPayload.swift
@@ -1,0 +1,17 @@
+//
+//  WebCheckoutPayload.swift
+//  WKWebViewBridge
+//
+//  Created by Dan Bovey on 19/11/2018.
+//  Copyright © 2018 Poq Studio Ltd. All rights reserved.
+//
+
+import Foundation
+
+struct WebCheckoutPayload: Codable {
+    /*! @abstract The name of the event from Web Checkout JS */
+    let name: String
+    
+    /*! @abstract data is a JSON string that can be decoded into the expected model based on name. e.g. Order */
+    let data: [String : String]
+}


### PR DESCRIPTION
Replaces the "change button colour" example with a full roundtrip (web -> native -> web) example with the injected Apple Pay button from the proposed Web Checkout JS lib.

The demo index.html loads the Web Checkout scripts from `http://127.0.0.1/dist/...`

So that requires you to run [http-server](https://www.npmjs.com/package/http-server) on the WebCheckoutJS repo whilst running as I'm not sure there's a quick and easy way to load resources in Xcode in the web view. 